### PR TITLE
fix(coolapk、api): 修复酷安 API 返回数据不符合预期时取不存在的字段值引发的空指针异常

### DIFF
--- a/app/src/main/java/com/lz233/onetext/activity/MainActivity.java
+++ b/app/src/main/java/com/lz233/onetext/activity/MainActivity.java
@@ -875,9 +875,10 @@ public class MainActivity extends BaseActivity implements EasyPermissions.Permis
                             if (appVersion > BuildConfig.VERSION_CODE) {
                                 Snackbar.make(rootView, R.string.check_new_version_text, Snackbar.LENGTH_SHORT).setAction(R.string.check_new_version_button, view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://coolapk.com/apk/com.lz233.onetext")))).show();
                             }
-                            editor.putLong("update_latest_refresh_time",System.currentTimeMillis());
+                            editor.putLong("update_latest_refresh_time", System.currentTimeMillis());
                             editor.apply();
-                        } catch (JSONException e) {
+                        } catch (JSONException | NullPointerException e) {
+                            // 修复酷安 API 返回数据不符合预期时取不存在的字段值引发的空指针异常
                             e.printStackTrace();
                         }
                     }


### PR DESCRIPTION
偶然发现一个可能造成一段时间主页面疯狂崩溃的 bug

# 这是日志

```
Sorry, the app crashed last time. If you want, please copy the log and send an email to lz23333333@gmail.com.

AppNamespace: com.lz233.onetext

AppVersion: 1.84-の

AppBuild: 20210121

OemName: OnePlus

Model: ONEPLUS A6010

OsName: Android

OsVersion: 9

OsApiLevel: 28

OsBuild: PKQ1.180716.001

SdkVersion: 3.2.2

Locale: en_US

ScreenSize: 1080x2261

ThreadName: 嘤嘤嘤嘤嘤.q Dispatcher

StackTrace:

java.lang.NullPointerException: Attempt to invoke virtual method 'int org.json.JSONObject.optInt(java.lang.String)' on a null object reference
 at 喵喵喵喵喵.喵喵喵喵.喵.喵喵喵.m1.喵(:2)
 at 嘤嘤嘤嘤嘤.z.嘤嘤嘤嘤嘤嘤.喵喵喵喵喵$喵.run(:6)
 at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
 at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
 at java.lang.Thread.run(Thread.java:764)
```

为什么 App 报的崩溃日志竟然是混淆过了的 = =？这样甚至不方便自己分析吧？我得用源码调试才知道问题所在（还是说有我不知道的奇淫技巧？=。=）

# 下面是正题
```java
@Override
public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
    try {
        int appVersion = new JSONObject(response.body().string()).optJSONObject("data").optInt("apkversioncode");
        ...
    } catch (JSONException e) {
        e.printStackTrace();
   }
}
```

拿 AppVersion 那句就是崩溃所在，你没有处理当 data 为空的情况，于是 null.optInt("apkversioncode") 就崩溃了。

举例返回数据：

```json
{
    "status": 1000,
    "error": null,
    "message": "请求方式错误"
}
```

复现也很容易，随便删一个 request header 就可以了